### PR TITLE
Y titles and params filename argument

### DIFF
--- a/viskit/core.py
+++ b/viskit/core.py
@@ -100,6 +100,7 @@ def lookup(d, keys):
 def load_exps_data(
         exp_folder_paths,
         data_filename='progress.csv',
+        params_filename='params.json',
         disable_variant=False,
 ):
     exps = []
@@ -109,7 +110,7 @@ def load_exps_data(
     for exp in exps:
         try:
             exp_path = exp
-            params_json_path = os.path.join(exp_path, "params.json")
+            params_json_path = os.path.join(exp_path, params_filename)
             variant_json_path = os.path.join(exp_path, "variant.json")
             progress_csv_path = os.path.join(exp_path, data_filename)
             if os.stat(progress_csv_path).st_size == 0:
@@ -123,7 +124,9 @@ def load_exps_data(
                 except IOError:
                     params = load_params(params_json_path)
             exps_data.append(AttrDict(
-                progress=progress, params=params, flat_params=flatten_dict(params)))
+                progress=progress,
+                params=params,
+                flat_params=flatten_dict(params)))
         except IOError as e:
             print(e)
     return exps_data

--- a/viskit/frontend.py
+++ b/viskit/frontend.py
@@ -99,7 +99,6 @@ def make_plot(
                 y_upper = list(plt.percentile75)
                 y_lower = list(plt.percentile25)
             else:
-                print('not using median')
                 if x_axis:
                     x = x_axis[idx][1]
                 else:

--- a/viskit/frontend.py
+++ b/viskit/frontend.py
@@ -823,7 +823,8 @@ def reload_data():
     global distinct_params
     exps_data = core.load_exps_data(
         args.data_paths,
-        args.dname,
+        args.data_filename,
+        args.params_filename,
         args.disable_variant,
     )
     plottable_keys = list(
@@ -839,7 +840,12 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action="store_true", default=False)
     parser.add_argument("--port", type=int, default=5000)
     parser.add_argument("--disable-variant", default=False, action='store_true')
-    parser.add_argument("--dname", default='progress.csv', help='name of data file')
+    parser.add_argument("--data-filename",
+                        default='progress.csv',
+                        help='name of data file.')
+    parser.add_argument("--params-filename",
+                        default='params.json',
+                        help='name of params file.')
     args = parser.parse_args(sys.argv[1:])
 
     # load all folders following a prefix

--- a/viskit/frontend.py
+++ b/viskit/frontend.py
@@ -83,6 +83,7 @@ def make_plot(
         height=plot_height,
         title=title,
     )
+
     for y_idx, plot_list in enumerate(plot_lists):
         for idx, plt in enumerate(plot_list):
             color = core.color_defaults[idx % len(core.color_defaults)]
@@ -129,8 +130,15 @@ def make_plot(
             fig.append_trace(values, y_idx_plotly, 1)
             if not x_axis:
                 fig.append_trace(errors, y_idx_plotly, 1)
+            title = plt.plot_key
+            if len(title) > 30:
+                title_parts = title.split('/')
+                title = "<br />/".join(
+                    title_parts[:-1]
+                    + [r"<b>{}</b>".format(t) for t in title_parts[-1:]]
+                )
             fig['layout']['yaxis{}'.format(y_idx_plotly)].update(
-                title=plt.plot_key,
+                title=title,
             )
             fig['layout']['xaxis{}'.format(y_idx_plotly)].update(
                 title=xlabel,


### PR DESCRIPTION
* Splits plot y-titles with '/', making long log values show up a bit nicer. Here's an example:
![image](https://user-images.githubusercontent.com/2308543/58200235-30a41680-7c87-11e9-85e6-783215e48968.png)
* Allows parameter filenames to be specified via command line args (`--params-filename`). Also changes the data filename flag to `--data-filename`.
* Removes "not using median" print