### PR TITLE
Fixes dependency issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-REQUIRED_PACKAGES = ['Flask==1.0.2', 'matplotlib==2.0.2', 'plotly==4.0.0', 'numpy==1.16.0', 'Jinja2==2.11.3']
+REQUIRED_PACKAGES = ['Flask==2.0.1', 'matplotlib==3.4.2', 'plotly==5.1.0', 'numpy==1.21.0', 'Jinja2==2.11.3']
 
 setup(name='viskit',
     version='0.1',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-REQUIRED_PACKAGES = ['Flask==1.0.2', 'matplotlib==2.0.2', 'plotly==4.0.0', 'numpy==1.16.0']
+REQUIRED_PACKAGES = ['Flask==1.0.2', 'matplotlib==2.0.2', 'plotly==4.0.0', 'numpy==1.16.0', 'Jinja2==2.11.3']
 
 setup(name='viskit',
     version='0.1',


### PR DESCRIPTION
Currently I am running into following issues when using the clean conda env and running `pip install -e . && python viskit/frontend.py <path>`:

```
[2021-06-29 16:29:58,750] ERROR in app: Exception on / [GET]
Traceback (most recent call last):
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "viskit/frontend.py", line 934, in index
    for k, v in distinct_params]),
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/templating.py", line 135, in render_template
    context, ctx.app)
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/flask/templating.py", line 117, in _render
    rv = template.render(context)
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/jorbik/miniconda3/envs/viskit-fail/lib/python3.6/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/jorbik/github/viskit/viskit/templates/main.html", line 148, in top-level template code
    {% if plottable_key in x_keys %}
jinja2.exceptions.UndefinedError: 'x_keys' is undefined
```

This dependency install fixes it.